### PR TITLE
Set dr mode to 'host' for usb_host0_xhci

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r68s.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r68s.dts
@@ -628,6 +628,7 @@
 
 &usb_host0_xhci {
 	extcon = <&usb2phy0>;
+	dr_mode = "host";
 	status = "okay";
 };
 


### PR DESCRIPTION
356x.dtsi 里的 mode 改成 otg 了，r68s 启动会有奇怪的崩溃

<img width="782" alt="图片" src="https://user-images.githubusercontent.com/4849177/185808491-019b825f-9ae6-4043-9bcb-84660136da2d.png">
